### PR TITLE
Report termination information

### DIFF
--- a/ringvax/__init__.py
+++ b/ringvax/__init__.py
@@ -81,7 +81,7 @@ class Simulation:
                     bisect.insort_right(infection_queue, (t, id), key=lambda x: x[0])
 
             if len(self.query_people()) >= self.params["max_infections"]:
-                termination["max_infections"] = True
+                termination["criterion"] = "max_infections"
                 min_in_progress = min(
                     self.infections[parent]["generation"]
                     for _, parent in infection_queue

--- a/ringvax/app.py
+++ b/ringvax/app.py
@@ -148,7 +148,7 @@ def app():
             )
             max_infections = st.number_input(
                 "Maximum number of infections",
-                value=100,
+                value=1000,
                 step=10,
                 min_value=100,
                 help="",
@@ -169,7 +169,9 @@ def app():
     }
 
     sims = []
-    with st.spinner("Running simulation..."):
+    with st.spinner(
+        "Running simulation... Slow simulations may indicate unreasonable parameter values leading to unrealistically large outbreaks."
+    ):
         tic = time.perf_counter()
         for i in range(nsim):
             sims.append(Simulation(params=params, seed=seed + i))
@@ -180,60 +182,102 @@ def app():
         f"Ran {nsim} simulations in {format_duration(toc - tic)} with an $R_0$ of {infectious_duration * infection_rate:.2f} (the product of the average duration of infection and the infectious rate)."
     )
 
-    tab1, tab2 = st.tabs(["Simulation summary", "Per-simulation results"])
-    with tab1:
-        sim_df = get_all_person_properties(sims)
+    n_at_max = sum(
+        1 for sim in sims if sim.termination["criterion"] == "max_infections"
+    )
 
-        pr_control = prob_control_by_gen(sim_df, control_generations)
-        st.header(
-            f"Probability of control: {pr_control:.0%}",
-            help=f"The probability that there are no infections in the {format_control_gens(control_generations)}, or equivalently that the {format_control_gens(control_generations - 1)} do not produce any further infections.",
+    show = True if n_at_max == 0 else False
+    if not show:
+        st.warning(
+            body=(
+                f"{n_at_max} simulations hit the specified maximum number of infections ({max_infections})."
+            ),
+            icon="🚨",
         )
 
-        st.header("Number of infections")
-        st.write(
-            f"Distribution of the total number of infections seen in {n_generations} generations."
+        st.warning(
+            body=(
+                "Simulations hitting the maximum likely indicate implausible parameter values. "
+                'It is recommended that you either adjust simulating parameters or increase "Maximum number of infections".'
+            ),
         )
-        st.altair_chart(
-            alt.Chart(get_outbreak_size_df(sim_df))
-            .mark_bar()
-            .encode(
-                x=alt.X("size:Q", bin=True, title="Number of infections"),
-                y=alt.Y("count()", title="Count"),
+
+        st.warning(
+            body=(
+                "Note that results are summarized only for simulations which do not exceed this maximum. "
+                "This means that simulations with large final sizes will be missing from the results, biasing results. "
+            ),
+        )
+
+        accept_terms_and_conditions = st.button(
+            "I accept that the results are biased and may not be meaningful. Please show them anyways."
+        )
+        if accept_terms_and_conditions:
+            show = True
+
+    if show:
+        if n_at_max == nsim:
+            st.error(
+                "No simulations completed successfully. Please change settings and try again.",
+                icon="🚨",
             )
-        )
+            st.stop()
 
-        st.header("Summary of dynamics")
-        infection = summarize_infections(sim_df)
-        st.write(
-            f"In these simulations, the average duration of infectiousness was {infection['mean_infectious_duration'][0]:.2f} and $R_e$ was {infection['mean_n_infections'][0]:.2f}"
-        )
+        tab1, tab2 = st.tabs(["Simulation summary", "Per-simulation results"])
+        with tab1:
+            sim_df = get_all_person_properties(sims)
 
-        st.write(
-            "The following table provides summaries of marginal probabilities regarding detection. Aside from the marginal probability of active detection, these are the observed probabilities that any individual is detected in this manner. The marginal probability of active detection excludes index cases, which are not eligible for active detection."
-        )
-        detection = summarize_detections(sim_df)
-        st.dataframe(
-            detection.select(
-                (pl.col(col) * 100).round(0).cast(pl.Int64) for col in detection.columns
+            pr_control = prob_control_by_gen(sim_df, control_generations)
+            st.header(
+                f"Probability of control: {pr_control:.0%}",
+                help=f"The probability that there are no infections in the {format_control_gens(control_generations)}, or equivalently that the {format_control_gens(control_generations - 1)} do not produce any further infections.",
             )
-            .with_columns(
-                pl.concat_str([pl.col(col), pl.lit("%")], separator="")
-                for col in detection.columns
-            )
-            .rename(
-                {
-                    "prob_detect": "Any detection",
-                    "prob_active": "Active detection",
-                    "prob_passive": "Passive detection",
-                    "prob_detect_before_infectious": "Detection before onset of infectiousness",
-                }
-            )
-        )
 
-    with tab2:
-        st.header("Graph of infections")
-        show_graph(sims=sims)
+            st.header("Number of infections")
+            st.write(
+                f"Distribution of the total number of infections seen in {n_generations} generations."
+            )
+            st.altair_chart(
+                alt.Chart(get_outbreak_size_df(sim_df))
+                .mark_bar()
+                .encode(
+                    x=alt.X("size:Q", bin=True, title="Number of infections"),
+                    y=alt.Y("count()", title="Count"),
+                )
+            )
+
+            st.header("Summary of dynamics")
+            infection = summarize_infections(sim_df)
+            st.write(
+                f"In these simulations, the average duration of infectiousness was {infection['mean_infectious_duration'][0]:.2f} and $R_e$ was {infection['mean_n_infections'][0]:.2f}"
+            )
+
+            st.write(
+                "The following table provides summaries of marginal probabilities regarding detection. Aside from the marginal probability of active detection, these are the observed probabilities that any individual is detected in this manner. The marginal probability of active detection excludes index cases, which are not eligible for active detection."
+            )
+            detection = summarize_detections(sim_df)
+            st.dataframe(
+                detection.select(
+                    (pl.col(col) * 100).round(0).cast(pl.Int64)
+                    for col in detection.columns
+                )
+                .with_columns(
+                    pl.concat_str([pl.col(col), pl.lit("%")], separator="")
+                    for col in detection.columns
+                )
+                .rename(
+                    {
+                        "prob_detect": "Any detection",
+                        "prob_active": "Active detection",
+                        "prob_passive": "Passive detection",
+                        "prob_detect_before_infectious": "Detection before onset of infectiousness",
+                    }
+                )
+            )
+
+        with tab2:
+            st.header("Graph of infections")
+            show_graph(sims=sims)
 
 
 if __name__ == "__main__":

--- a/ringvax/app.py
+++ b/ringvax/app.py
@@ -9,7 +9,7 @@ import streamlit as st
 from ringvax import Simulation
 from ringvax.summary import (
     get_all_person_properties,
-    get_outbreak_size_df,
+    get_total_infection_count_df,
     prob_control_by_gen,
     summarize_detections,
     summarize_infections,
@@ -170,7 +170,7 @@ def app():
 
     sims = []
     with st.spinner(
-        "Running simulation... Slow simulations may indicate unreasonable parameter values leading to unrealistically large outbreaks."
+        "Running simulation... Slow simulations may indicate unreasonable parameter values leading to unrealistically large total numbers of infections."
     ):
         tic = time.perf_counter()
         for i in range(nsim):
@@ -238,7 +238,7 @@ def app():
                 f"Distribution of the total number of infections seen in {n_generations} generations."
             )
             st.altair_chart(
-                alt.Chart(get_outbreak_size_df(sim_df))
+                alt.Chart(get_total_infection_count_df(sim_df))
                 .mark_bar()
                 .encode(
                     x=alt.X("size:Q", bin=True, title="Number of infections"),

--- a/ringvax/app.py
+++ b/ringvax/app.py
@@ -168,18 +168,28 @@ def app():
         "max_infections": max_infections,
     }
 
+    progress_text = (
+        "Running simulation... Slow simulations may indicate unreasonable "
+        "parameter values leading to unrealistically large total numbers of "
+        "infections."
+    )
+    progress_bar = st.progress(0, text=progress_text)
+
     sims = []
-    with st.spinner(
-        "Running simulation... Slow simulations may indicate unreasonable parameter values leading to unrealistically large total numbers of infections."
-    ):
-        tic = time.perf_counter()
-        for i in range(nsim):
-            sims.append(Simulation(params=params, seed=seed + i))
-            sims[-1].run()
-        toc = time.perf_counter()
+    tic = time.perf_counter()
+    for i in range(nsim):
+        progress_bar.progress(i / nsim, text=progress_text)
+        sim = Simulation(params=params, seed=seed + i)
+        sim.run()
+        sims.append(sim)
+
+    progress_bar.empty()
+    toc = time.perf_counter()
 
     st.write(
-        f"Ran {nsim} simulations in {format_duration(toc - tic)} with an $R_0$ of {infectious_duration * infection_rate:.2f} (the product of the average duration of infection and the infectious rate)."
+        f"Ran {nsim} simulations in {format_duration(toc - tic)} with an $R_0$ "
+        f"of {infectious_duration * infection_rate:.2f} (the product of the "
+        "average duration of infection and the infectious rate)."
     )
 
     n_at_max = sum(

--- a/ringvax/summary.py
+++ b/ringvax/summary.py
@@ -151,7 +151,7 @@ def prob_control_by_gen(df: pl.DataFrame, gen: int) -> float:
     return 1.0 - (size_at_gen.shape[0] / n_sim)
 
 
-def get_outbreak_size_df(df: pl.DataFrame) -> pl.DataFrame:
+def get_total_infection_count_df(df: pl.DataFrame) -> pl.DataFrame:
     """
     Get DataFrame of all total outbreak sizes from simulations
     """

--- a/ringvax/summary.py
+++ b/ringvax/summary.py
@@ -1,41 +1,27 @@
-from collections import Counter
-from typing import Container, Sequence
+from typing import Sequence
 
 import numpy as np
 import polars as pl
 
 from ringvax import Simulation
 
-infection_schema = {
-    "infector": pl.String,
-    "generation": pl.Int64,
-    "t_exposed": pl.Float64,
-    "t_infectious": pl.Float64,
-    "t_recovered": pl.Float64,
-    "infection_rate": pl.Float64,
-    "detected": pl.Boolean,
-    "detect_method": pl.String,
-    "t_detected": pl.Float64,
-    "infection_times": pl.List(pl.Float64),
-}
+infection_schema = pl.Schema(
+    {
+        "infector": pl.String,
+        "generation": pl.Int64,
+        "t_exposed": pl.Float64,
+        "t_infectious": pl.Float64,
+        "t_recovered": pl.Float64,
+        "infection_rate": pl.Float64,
+        "detected": pl.Boolean,
+        "detect_method": pl.String,
+        "t_detected": pl.Float64,
+        "infection_times": pl.List(pl.Float64),
+    }
+)
 """
 An infection as a polars schema
 """
-
-
-def prepare_for_df(infection: dict) -> dict:
-    """
-    Handle vector-valued infection properties for downstream use in pl.DataFrame
-    """
-    dfable = {}
-    for k, v in infection.items():
-        if isinstance(v, np.ndarray):
-            assert k == "infection_times"
-            dfable |= {k: [float(vv) for vv in v]}
-        else:
-            assert isinstance(v, str) or not isinstance(v, Container)
-            dfable |= {k: v}
-    return dfable
 
 
 def get_all_person_properties(
@@ -44,28 +30,37 @@ def get_all_person_properties(
     """
     Get a dataframe of all properties of all infections
     """
-    g_max = [sim.params["n_generations"] for sim in sims]
     assert (
-        len(Counter(g_max).items()) == 1
+        len(set(sim.params["n_generations"] for sim in sims)) == 1
     ), "Aggregating simulations with different `n_generations` is nonsensical"
 
-    i_max = [sim.params["max_infections"] for sim in sims]
     assert (
-        len(Counter(i_max).items()) == 1
+        len(set(sim.params["max_infections"] for sim in sims)) == 1
     ), "Aggregating simulations with different `max_infections` is nonsensical"
 
-    per_sim = []
-    for idx, sim in enumerate(sims):
-        if sim.termination["criterion"] not in exclude_termination_if:
-            sims_dict = {k: [] for k in infection_schema.keys()} | {
-                "simulation": [idx] * len(sim.infections)
-            }
-            for infection in sim.infections.values():
-                prep = prepare_for_df(infection)
-                for k in infection_schema.keys():
-                    sims_dict[k].append(prep[k])
-            per_sim.append(pl.DataFrame(sims_dict).cast(infection_schema))  # type: ignore
-    return pl.concat(per_sim)
+    return pl.concat(
+        [
+            _get_person_properties(sim).with_columns(simulation=sim_idx)
+            for sim_idx, sim in enumerate(sims)
+            if sim.termination["criterion"] not in exclude_termination_if
+        ]
+    )
+
+
+def _get_person_properties(sim: Simulation) -> pl.DataFrame:
+    """Get a DataFrame of all properties of all infections in a simulation"""
+    return pl.from_dicts(
+        [_prepare_for_df(x) for x in sim.infections.values()], schema=infection_schema
+    )
+
+
+def _prepare_for_df(infection: dict) -> dict:
+    """
+    Convert numpy arrays in a dictionary to lists, for DataFrame compatibility
+    """
+    return {
+        k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in infection.items()
+    }
 
 
 def summarize_detections(df: pl.DataFrame) -> pl.DataFrame:

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,58 @@
+import types
+
+import numpy as np
+import polars as pl
+
+import ringvax
+import ringvax.summary
+
+
+def test_prep_for_df():
+    infection = {"infection_times": np.array([0, 1, 2]), "detected": False}
+    assert ringvax.summary.prepare_for_df(infection) == {
+        "infection_times": [0, 1, 2],
+        "detected": False,
+    }
+
+
+def test_get_all_person_properties():
+    infections = {
+        "index": {
+            "infector": None,
+            "generation": 0,
+            "t_exposed": 0.0,
+            "t_infectious": 1.0,
+            "t_recovered": 2.0,
+            "infection_rate": 0.5,
+            "detected": False,
+            "detect_method": None,
+            "t_detected": None,
+            "infection_times": np.array([1.1, 1.2, 1.3]),
+        },
+        "first_person": {
+            "infector": "index",
+            "generation": 1,
+            "t_exposed": 1.1,
+            "t_infectious": 2.1,
+            "t_recovered": 3.1,
+            "infection_rate": 0.5,
+            "detected": True,
+            "detect_method": "passive",
+            "t_detected": 1.5,
+            "infection_times": np.array(()),
+        },
+    }
+    params = {"n_generations": 1, "max_infections": 10}
+    termination = {"criterion": "extinction"}
+    sim1 = types.SimpleNamespace(
+        params=params, infections=infections, termination=termination
+    )
+    sim2 = types.SimpleNamespace(
+        params=params, infections=infections, termination=termination
+    )
+
+    x = ringvax.summary.get_all_person_properties([sim1, sim2])  # type: ignore
+
+    # result should be a data frame of length 4
+    assert isinstance(x, pl.DataFrame)
+    assert x.shape[0] == 4

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -9,7 +9,7 @@ import ringvax.summary
 
 def test_prep_for_df():
     infection = {"infection_times": np.array([0, 1, 2]), "detected": False}
-    assert ringvax.summary.prepare_for_df(infection) == {
+    assert ringvax.summary._prepare_for_df(infection) == {
         "infection_times": [0, 1, 2],
         "detected": False,
     }


### PR DESCRIPTION
Revised per synchronous discussion, this PR now:
- Tracks simulation termination
- Excludes simulations from computation when they stop due to `max_infections`
  - It also checks for 0 successful simulations and throws an `st.error` instead of a runtime error.
- Warns users if `max_infections` is being hit and requires them to acknowledge the potentially-fraught results.
- Adds to the spin wheel text to say that simulations being very slow is probably bad news.

Known issues:
- I'm pretty sure if you say "show me anyways" it re-runs the simulations. We could maybe wrap the entire display code into a function and decorate it with an `st.fragment` but since this is already ill-advised usage, that seems like overkill.