### PR TITLE
Check for person properties

### DIFF
--- a/ringvax/__init__.py
+++ b/ringvax/__init__.py
@@ -28,7 +28,7 @@ class Simulation:
     def create_person(self) -> str:
         """Add a new person to the data"""
         id = str(len(self.infections))
-        self.infections[id] = {field: None for field in self.PROPERTIES}
+        self.infections[id] = {x: None for x in self.PROPERTIES}
         return id
 
     def update_person(self, id: str, content: dict[str, Any]) -> None:

--- a/ringvax/__init__.py
+++ b/ringvax/__init__.py
@@ -6,6 +6,19 @@ import numpy.random
 
 
 class Simulation:
+    PROPERTIES = [
+        "infector",
+        "generation",
+        "t_exposed",
+        "t_infectious",
+        "t_recovered",
+        "infection_rate",
+        "detected",
+        "detect_method",
+        "t_detected",
+        "infection_times",
+    ]
+
     def __init__(self, params: dict[str, Any], seed: Optional[int] = None):
         self.params = params
         self.seed = seed
@@ -15,14 +28,21 @@ class Simulation:
     def create_person(self) -> str:
         """Add a new person to the data"""
         id = str(len(self.infections))
-        self.infections[id] = {}
+        self.infections[id] = {field: None for field in self.PROPERTIES}
         return id
 
     def update_person(self, id: str, content: dict[str, Any]) -> None:
+        bad_properties = set(content.keys()) - set(self.PROPERTIES)
+        if len(bad_properties) > 0:
+            raise RuntimeError(f"Properties not in schema: {bad_properties}")
+
         self.infections[id] |= content
 
     def get_person_property(self, id: str, property: str) -> Any:
         """Get a property of a person"""
+        if property not in self.PROPERTIES:
+            raise RuntimeError(f"Property '{property}' not in schema")
+
         if id not in self.infections:
             raise RuntimeError(f"No person with {id=}")
         elif property not in self.infections[id]:

--- a/ringvax/__init__.py
+++ b/ringvax/__init__.py
@@ -6,7 +6,7 @@ import numpy.random
 
 
 class Simulation:
-    PROPERTIES = [
+    PROPERTIES = {
         "infector",
         "generation",
         "t_exposed",
@@ -17,7 +17,7 @@ class Simulation:
         "detect_method",
         "t_detected",
         "infection_times",
-    ]
+    }
 
     def __init__(self, params: dict[str, Any], seed: Optional[int] = None):
         self.params = params

--- a/ringvax/summary.py
+++ b/ringvax/summary.py
@@ -22,6 +22,8 @@ infection_schema = {
 An infection as a polars schema
 """
 
+assert set(infection_schema.keys()) == set(Simulation.PROPERTIES)
+
 
 def prepare_for_df(infection: dict) -> dict:
     """

--- a/ringvax/summary.py
+++ b/ringvax/summary.py
@@ -22,7 +22,7 @@ infection_schema = {
 An infection as a polars schema
 """
 
-assert set(infection_schema.keys()) == set(Simulation.PROPERTIES)
+assert set(infection_schema.keys()) == Simulation.PROPERTIES
 
 
 def prepare_for_df(infection: dict) -> dict:


### PR DESCRIPTION
- There is a list of person properties
- When a new person is created, these properties are all set to `None`
- When a property is updated or queried, it is first checked against this list
- There is a check that the schema used for making the polars data frame summarizes has the same names as the properties in the simulation

Resolves #22 