### PR TITLE
Separate detection history into draws vs. logic

### DIFF
--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -157,7 +157,6 @@ def test_snapshot(rng):
         snapshot = json.load(f)
 
     assert s.infections == snapshot
-    assert len(s.infections) == 10
 
 
 class TestResolveDetectionHistory:

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -16,24 +16,20 @@ def rng():
 def test_infection_delays_zero_rate(rng):
     """If zero rate, zero infections"""
     assert (
-        list(
-            ringvax.Simulation.generate_infection_waiting_times(
-                rng, rate=0.0, infectious_duration=100.0
-            )
-        )
-        == []
+        ringvax.Simulation.generate_infection_waiting_times(
+            rng, rate=0.0, infectious_duration=100.0
+        ).size
+        == 0
     )
 
 
 def test_infection_delays_zero_duration(rng):
     """If zero duration, zero infections"""
     assert (
-        list(
-            ringvax.Simulation.generate_infection_waiting_times(
-                rng, rate=100.0, infectious_duration=0.0
-            )
-        )
-        == []
+        ringvax.Simulation.generate_infection_waiting_times(
+            rng, rate=100.0, infectious_duration=0.0
+        ).size
+        == 0
     )
 
 
@@ -161,3 +157,8 @@ def test_snapshot(rng):
         snapshot = json.load(f)
 
     assert s.infections == snapshot
+    assert len(s.infections) == 10
+
+
+def test_detection_history():
+    pass

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -191,7 +191,7 @@ class TestResolveDetectionHistory:
         kwargs["potentially_passive_detected"] = True
         assert self.f(kwargs) == {
             "detected": True,
-            "t_detected": 0.0 + 5.0,
+            "t_detected": 5.0,
             "detect_method": "passive",
         }
 

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -174,13 +174,9 @@ class TestResolveDetectionHistory:
             "t_infector_detected": None,
         }
 
-    @staticmethod
-    def f(kwargs: dict):
-        return ringvax.Simulation.resolve_detection_history(**kwargs)
-
     def test_baseline(self, kwargs):
         """No potential detections"""
-        assert self.f(kwargs) == {
+        assert ringvax.Simulation.resolve_detection_history(**kwargs) == {
             "detected": False,
             "t_detected": None,
             "detect_method": None,
@@ -189,7 +185,7 @@ class TestResolveDetectionHistory:
     def test_passive_only(self, kwargs):
         """Passive detection only"""
         kwargs["potentially_passive_detected"] = True
-        assert self.f(kwargs) == {
+        assert ringvax.Simulation.resolve_detection_history(**kwargs) == {
             "detected": True,
             "t_detected": 5.0,
             "detect_method": "passive",
@@ -199,7 +195,7 @@ class TestResolveDetectionHistory:
         """Passive detection after recovery"""
         kwargs["potentially_passive_detected"] = True
         kwargs["passive_detection_delay"] = 11.0
-        assert self.f(kwargs) == {
+        assert ringvax.Simulation.resolve_detection_history(**kwargs) == {
             "detected": False,
             "t_detected": None,
             "detect_method": None,
@@ -209,7 +205,7 @@ class TestResolveDetectionHistory:
         """Active detection only"""
         kwargs["potentially_active_detected"] = True
         kwargs["t_infector_detected"] = 0.0
-        assert self.f(kwargs) == {
+        assert ringvax.Simulation.resolve_detection_history(**kwargs) == {
             "detected": True,
             "t_detected": 0.0 + 2.0,
             "detect_method": "active",
@@ -220,7 +216,7 @@ class TestResolveDetectionHistory:
         kwargs["potentially_active_detected"] = True
         kwargs["t_infector_detected"] = 5.0
         kwargs["active_detection_delay"] = 6.0
-        assert self.f(kwargs) == {
+        assert ringvax.Simulation.resolve_detection_history(**kwargs) == {
             "detected": False,
             "t_detected": None,
             "detect_method": None,
@@ -231,7 +227,7 @@ class TestResolveDetectionHistory:
         kwargs["potentially_passive_detected"] = True
         kwargs["potentially_active_detected"] = True
         kwargs["t_infector_detected"] = 5.0
-        assert self.f(kwargs) == {
+        assert ringvax.Simulation.resolve_detection_history(**kwargs) == {
             "detected": True,
             "t_detected": 5.0,
             "detect_method": "passive",
@@ -242,7 +238,7 @@ class TestResolveDetectionHistory:
         kwargs["potentially_passive_detected"] = True
         kwargs["potentially_active_detected"] = True
         kwargs["t_infector_detected"] = 1.0
-        assert self.f(kwargs) == {
+        assert ringvax.Simulation.resolve_detection_history(**kwargs) == {
             "detected": True,
             "t_detected": 1.0 + 2.0,
             "detect_method": "active",
@@ -254,7 +250,7 @@ class TestResolveDetectionHistory:
         kwargs["potentially_active_detected"] = True
         kwargs["t_infector_detected"] = 9.0
         kwargs["passive_detection_delay"] = 11.0
-        assert self.f(kwargs) == {
+        assert ringvax.Simulation.resolve_detection_history(**kwargs) == {
             "detected": False,
             "t_detected": None,
             "detect_method": None,

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -233,7 +233,7 @@ class TestResolveDetectionHistory:
         kwargs["t_infector_detected"] = 5.0
         assert self.f(kwargs) == {
             "detected": True,
-            "t_detected": 0.0 + 5.0,
+            "t_detected": 5.0,
             "detect_method": "passive",
         }
 


### PR DESCRIPTION
Aims to resolve #14  -- There are tests for all parts of the logic except the detection resolution

- This PR separates detection into generation of the relevant quantities, and then the resolution
- I got around the crazy branching logic by making a list of potential detections (length 0, 1, or 2) and filtering it
- Add tests for each possible situation:
  - Not eligible for passive nor active
  - Eligible for passive only, and detected
  - Eligible for passive only, but detection after recovery, so no detection
  - 2x tests for active, like the above
  - Both trigger, one of them wins (x2)
  - Both trigger, neither wins