### PR TITLE
Refactor summarization

### DIFF
--- a/ringvax/summary.py
+++ b/ringvax/summary.py
@@ -6,18 +6,20 @@ import polars as pl
 
 from ringvax import Simulation
 
-infection_schema = {
-    "infector": pl.String,
-    "generation": pl.Int64,
-    "t_exposed": pl.Float64,
-    "t_infectious": pl.Float64,
-    "t_recovered": pl.Float64,
-    "infection_rate": pl.Float64,
-    "detected": pl.Boolean,
-    "detect_method": pl.String,
-    "t_detected": pl.Float64,
-    "infection_times": pl.List(pl.Float64),
-}
+infection_schema = pl.Schema(
+    {
+        "infector": pl.String,
+        "generation": pl.Int64,
+        "t_exposed": pl.Float64,
+        "t_infectious": pl.Float64,
+        "t_recovered": pl.Float64,
+        "infection_rate": pl.Float64,
+        "detected": pl.Boolean,
+        "detect_method": pl.String,
+        "t_detected": pl.Float64,
+        "infection_times": pl.List(pl.Float64),
+    }
+)
 """
 An infection as a polars schema
 """
@@ -70,7 +72,7 @@ def get_person_properties(sim: Simulation) -> pl.DataFrame:
         for k in infection_schema.keys():
             sims_dict[k].append(prep[k])
 
-    return pl.DataFrame(sims_dict).cast(infection_schema)  # type: ignore
+    return pl.DataFrame(sims_dict, schema=infection_schema)
 
 
 def summarize_detections(df: pl.DataFrame) -> pl.DataFrame:

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -9,7 +9,7 @@ import ringvax.summary
 
 def test_prep_for_df():
     infection = {"infection_times": np.array([0, 1, 2]), "detected": False}
-    assert ringvax.summary.prepare_for_df(infection) == {
+    assert ringvax.summary._prepare_for_df(infection) == {
         "infection_times": [0, 1, 2],
         "detected": False,
     }


### PR DESCRIPTION
- Use a polars schema, rather than casting
- Write `get_all_person_properties()` as a list comprehension, adding simulation index after the constituent data frames are made
- For the intermediate function that gets person properties from one simulation, use `pl.from_dicts()`
- Rewrite `prepare_for_df` as a dict comprehension

Builds on top of #44 , which should likely be merged first