### PR TITLE
Use rng, not seed

### DIFF
--- a/ringvax/__init__.py
+++ b/ringvax/__init__.py
@@ -19,10 +19,11 @@ class Simulation:
         "infection_times",
     }
 
-    def __init__(self, params: dict[str, Any], seed: Optional[int] = None):
+    def __init__(
+        self, params: dict[str, Any], rng: Optional[numpy.random.Generator] = None
+    ):
         self.params = params
-        self.seed = seed
-        self.rng = numpy.random.default_rng(self.seed)
+        self.rng = rng if rng is not None else numpy.random.default_rng()
         self.infections = {}
         self.termination: Optional[str] = None
 

--- a/ringvax/app.py
+++ b/ringvax/app.py
@@ -3,6 +3,7 @@ from typing import List
 
 import altair as alt
 import graphviz
+import numpy.random
 import polars as pl
 import streamlit as st
 
@@ -175,16 +176,22 @@ def app():
     )
     progress_bar = st.progress(0, text=progress_text)
 
-    sims = []
+    # run simulations ---------------------------------------------------------
     tic = time.perf_counter()
+    sims = []
+
+    # initialize rngs
+    rngs = numpy.random.default_rng(seed).spawn(nsim)
+
     for i in range(nsim):
         progress_bar.progress(i / nsim, text=progress_text)
-        sim = Simulation(params=params, seed=seed + i)
+        sim = Simulation(params=params, rng=rngs[i])
         sim.run()
         sims.append(sim)
 
     progress_bar.empty()
     toc = time.perf_counter()
+    # end simulations ---------------------------------------------------------
 
     st.write(
         f"Ran {nsim} simulations in {format_duration(toc - tic)} with an $R_0$ "

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -151,7 +151,7 @@ def test_snapshot(rng):
         "active_detection_delay": 2.0,
         "max_infections": 100,
     }
-    s = ringvax.Simulation(params=params, seed=rng)
+    s = ringvax.Simulation(params=params, rng=rng)
     s.run()
 
     for x in s.infections.values():

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -57,7 +57,7 @@ def test_generate_disease_history(rng):
         "infectious_duration": 1.0,
         "infection_rate": 2.0,
     }
-    s = ringvax.Simulation(params=params, seed=rng)
+    s = ringvax.Simulation(params=params, rng=rng)
     history = s.generate_disease_history(t_exposed=0.0)
     # for ease of testing, make this a list of rounded numbers
 
@@ -77,7 +77,7 @@ def test_generate_disease_history_nonzero(rng):
         "infectious_duration": 1.0,
         "infection_rate": 2.0,
     }
-    s = ringvax.Simulation(params=params, seed=rng)
+    s = ringvax.Simulation(params=params, rng=rng)
     history = s.generate_disease_history(t_exposed=10.0)
     assert history == {
         "t_exposed": 10.0,
@@ -103,7 +103,7 @@ def base_params():
 
 
 def test_simulate(rng, base_params):
-    s = ringvax.Simulation(params=base_params, seed=rng)
+    s = ringvax.Simulation(params=base_params, rng=rng)
     s.run()
     assert len(s.infections) == 19
 
@@ -111,20 +111,20 @@ def test_simulate(rng, base_params):
 def test_simulate_max_infections(rng, base_params):
     params = base_params
     params["max_infections"] = 10
-    s = ringvax.Simulation(params=params, seed=rng)
+    s = ringvax.Simulation(params=params, rng=rng)
     s.run()
     assert len(s.infections) == 10
 
 
 def test_simulate_set_field(rng, base_params):
-    s = ringvax.Simulation(params=base_params, seed=rng)
+    s = ringvax.Simulation(params=base_params, rng=rng)
     id = s.create_person()
     s.update_person(id, {"generation": 0})
     assert s.get_person_property(id, "generation") == 0
 
 
 def test_simulate_error_on_bad_get_property(rng, base_params):
-    s = ringvax.Simulation(params=base_params, seed=rng)
+    s = ringvax.Simulation(params=base_params, rng=rng)
     id = s.create_person()
 
     with pytest.raises(RuntimeError, match="foo"):
@@ -132,7 +132,7 @@ def test_simulate_error_on_bad_get_property(rng, base_params):
 
 
 def test_simulate_error_on_bad_update_property(rng, base_params):
-    s = ringvax.Simulation(params=base_params, seed=rng)
+    s = ringvax.Simulation(params=base_params, rng=rng)
     id = s.create_person()
 
     with pytest.raises(RuntimeError, match="foo"):


### PR DESCRIPTION
- Always pass a `numpy.random.Generator` to `Simulation`, rather than an integer seed
- Use `.spawn()` to create the rngs for each simulation