### PR TITLE
Cache simulation results

### DIFF
--- a/ringvax/app.py
+++ b/ringvax/app.py
@@ -18,6 +18,44 @@ from ringvax.summary import (
 )
 
 
+@st.cache_data
+def run_simulations(n: int, params: dict, seed: int) -> List[Simulation]:
+    """
+    Run simulations and display progress bar
+
+    Args:
+        n (int): number of simulations
+        params (dict): simulation parameters
+        seed (int): random seed
+    """
+
+    progress_text = (
+        "Running simulation... Slow simulations may indicate unreasonable "
+        "parameter values leading to unrealistically large total numbers of "
+        "infections."
+    )
+    progress_bar = st.progress(0, text=progress_text)
+
+    tic = time.perf_counter()
+    sims = []
+
+    # initialize rngs
+    rngs = numpy.random.default_rng(seed).spawn(n)
+
+    for i in range(n):
+        progress_bar.progress(i / n, text=progress_text)
+        sim = Simulation(params=params, rng=rngs[i])
+        sim.run()
+        sims.append(sim)
+
+    progress_bar.empty()
+    toc = time.perf_counter()
+
+    st.write(f"Ran {n} simulations in {format_duration(toc - tic)}")
+
+    return sims
+
+
 def render_percents(df: pl.DataFrame) -> pl.DataFrame:
     return df.with_columns(
         pl.when(pl.col(col).is_nan())
@@ -259,31 +297,9 @@ def app():
         "max_infections": max_infections,
     }
 
-    progress_text = (
-        "Running simulation... Slow simulations may indicate unreasonable "
-        "parameter values leading to unrealistically large total numbers of "
-        "infections."
-    )
-    progress_bar = st.progress(0, text=progress_text)
-
     # run simulations ---------------------------------------------------------
-    tic = time.perf_counter()
-    sims = []
 
-    # initialize rngs
-    rngs = numpy.random.default_rng(seed).spawn(nsim)
-
-    for i in range(nsim):
-        progress_bar.progress(i / nsim, text=progress_text)
-        sim = Simulation(params=params, rng=rngs[i])
-        sim.run()
-        sims.append(sim)
-
-    progress_bar.empty()
-    toc = time.perf_counter()
-    # end simulations ---------------------------------------------------------
-
-    st.write(f"Ran {nsim} simulations in {format_duration(toc - tic)}")
+    sims = run_simulations(n=nsim, params=params, seed=seed)
 
     n_at_max = sum(1 for sim in sims if sim.termination == "max_infections")
 


### PR DESCRIPTION
Resolves #51 , to a degree

Our original idea, as per #51, was to remove the `@st.fragment` from the graphing and instead `@st.cache_data` the simulations.

Here, I add the `@st.cache_data`. For the cost of refactoring the simulation runner into a function (probably a good thing anyway), and a single decorator line, you get marginally improved speeds if you happen to pick the exact same parameters twice.

Subsequently removing the `@st.fragment` leads to a small but noticeable (additional) lag. I suspect this is due to streamlit's behavior of caching by copying. Without `@st.fragment`, every new graph means that we need to deep copy the list of simulation results.

I think this means we should:

1. Accept this PR, or not. It's probably overall better code, but the caching doesn't really add that much.
2. Resolve #51, since it seems like we're pretty near optimal anyway, and `@st.fragment` does seem like the right choice, to make the graphing as smooth as possible.

We might want to revisit no.2 after #55 (or similar) is merged, but I suspect we are in pretty good shape with `@st.fragment`.