### PR TITLE
Improve git commit tagging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
       build-essential \
       curl \
       software-properties-common \
+      git \
     && rm -rf /var/lib/apt/lists/*
 
 COPY . .

--- a/ringvax/app.py
+++ b/ringvax/app.py
@@ -161,14 +161,17 @@ def set_session_default(key, value) -> None:
 
 
 def get_commit(length: int = 15) -> Optional[str]:
-    x = subprocess.run(
-        ["git", "rev-parse", f"--short={length}", "HEAD"], capture_output=True
-    )
-    if x.returncode == 0:
-        commit = x.stdout.decode().strip()
-        assert len(commit) == length
-        return commit
-    else:
+    try:
+        x = subprocess.run(
+            ["git", "rev-parse", f"--short={length}", "HEAD"], capture_output=True
+        )
+        if x.returncode == 0:
+            commit = x.stdout.decode().strip()
+            assert len(commit) == length
+            return commit
+        else:
+            return None
+    except subprocess.CalledProcessError:
         return None
 
 

--- a/ringvax/app.py
+++ b/ringvax/app.py
@@ -171,7 +171,7 @@ def get_commit(length: int = 15) -> Optional[str]:
             return commit
         else:
             return None
-    except subprocess.CalledProcessError:
+    except FileNotFoundError:
         return None
 
 


### PR DESCRIPTION
If git isn't installed, then `subprocess.run(['git'])` throws a `FileNotFoundError`. This led to bug #75.

- Wrap commit finding in a try/except, so that if `FileNotFoundError` is thrown, we don't error out.
- Add git to the container, so we don't have this problem in the first place.

Resolves #75 