### PR TITLE
Instantiate infections upon exposure

### DIFF
--- a/ringvax/__init__.py
+++ b/ringvax/__init__.py
@@ -87,7 +87,6 @@ class Simulation:
         passed_max_generations = False
 
         while True:
-            # print(f">>> Looping, there are {len(self.query_people())} infections")
             # in each pass through this loop, we:
             # - exit the loop if needed
             # - pop one infection off the queue and instantiate it
@@ -178,7 +177,7 @@ class Simulation:
             assert (infection_times <= t_end_infectious).all()
 
         infectees = [
-            self.create_person(id, time, self.get_person_property(id, "generation"))
+            self.create_person(id, time, self.get_person_property(id, "generation") + 1)
             for time in infection_times
         ]
         self.update_person(

--- a/ringvax/__init__.py
+++ b/ringvax/__init__.py
@@ -39,6 +39,7 @@ class Simulation:
         """Add a new person to the data"""
         id = str(len(self.infections))
         self.infections[id] = {
+            "id": id,
             "infector": infector,
             "t_exposed": t_exposed,
             "generation": generation,

--- a/ringvax/app.py
+++ b/ringvax/app.py
@@ -306,7 +306,7 @@ def app():
                 == "Cumulative"
             )
 
-    max_infections = 1000
+    max_infections = 1000000
     params = {
         "n_generations": n_generations,
         "latent_duration": latent_duration,

--- a/ringvax/app.py
+++ b/ringvax/app.py
@@ -284,13 +284,6 @@ def app():
                 max_value=n_generations + 1,
                 help="Successful control is defined as no infections in contacts at this degree. Set to 1 for contacts of the index case, 2 for contacts of contacts, etc. Equivalent to checking for extinction in the specified generation.",
             )
-            max_infections = st.number_input(
-                "Maximum number of infections",
-                value=1000,
-                step=10,
-                min_value=100,
-                help="",
-            )
             seed = st.number_input("Random seed", value=1234, step=1)
             nsim = st.number_input("Number of simulations", value=250, step=1)
             plot_gen = st.toggle("Show infection's generation", value=False)
@@ -313,6 +306,7 @@ def app():
                 == "Cumulative"
             )
 
+    max_infections = 1000
     params = {
         "n_generations": n_generations,
         "latent_duration": latent_duration,

--- a/ringvax/plot.py
+++ b/ringvax/plot.py
@@ -225,7 +225,11 @@ def get_infection_time_tuples(id: str, sim: Simulation):
     if infectees is None or len(infectees) == 0:
         return None
 
-    return [(sim.get_person_property(inf, "t_exposed"), inf) for inf in infectees]
+    return [
+        (sim.get_person_property(inf, "t_exposed"), inf)
+        for inf in infectees
+        if sim.get_person_property(inf, "simulated")
+    ]
 
 
 def order_descendants(sim: Simulation):
@@ -257,6 +261,7 @@ def make_plot_par(sim: Simulation, show_counterfactual=True):
     Get parameters for plotting this simulation
     """
     plot_order = order_descendants(sim)
+    print(plot_order)
 
     return {
         "annotate_generation": True,
@@ -282,21 +287,21 @@ def make_plot_par(sim: Simulation, show_counterfactual=True):
             0.0,
             max(
                 sim.get_person_property(id, stage_map["infectious"]["end"])
-                for id in sim.infections.keys()
+                for id in sim.query_people({"simulated": True})
             ),
         ],
-        "y_range": [-1.0, len(sim.infections)],
+        "y_range": [-1.0, len(sim.query_people({"simulated": True}))],
     }
 
 
 def plot_simulation(sim: Simulation, par: dict[str, Any]):
-    n_inf = len(sim.query_people())
+    n_inf = len(sim.query_people({"simulated": True}))
 
     plot_par = make_plot_par(sim) | par
 
     fig, ax = plt.subplots()
 
-    for inf in sim.query_people():
+    for inf in sim.query_people({"simulated": True}):
         draw_stages(ax, inf, sim, plot_par)
 
         mark_infections(ax, inf, sim, plot_par)

--- a/ringvax/summary.py
+++ b/ringvax/summary.py
@@ -9,6 +9,7 @@ infection_schema = pl.Schema(
     {
         "id": pl.String,
         "infector": pl.String,
+        "simulated": pl.Boolean,
         "infectees": pl.List(pl.String),
         "generation": pl.Int64,
         "t_exposed": pl.Float64,

--- a/ringvax/summary.py
+++ b/ringvax/summary.py
@@ -30,7 +30,8 @@ assert set(infection_schema.keys()) == Simulation.PROPERTIES
 
 
 def get_all_person_properties(
-    sims: Sequence[Simulation], exclude_termination_if: list[str] = ["max_infections"]
+    sims: Sequence[Simulation],
+    exclude_termination_if: list[str] = [],
 ) -> pl.DataFrame:
     """
     Get a dataframe of all properties of all infections
@@ -83,6 +84,8 @@ def empirical_detection_prob(
 
     Returns proportion, numerator count, and denominator count.
     """
+    df = df.filter(pl.col("simulated"))
+
     if conditional_column is not None:
         assert conditional_column in df.columns
         assert df.schema[conditional_column] == pl.Boolean
@@ -123,6 +126,7 @@ def summarize_detections(df: pl.DataFrame) -> pl.DataFrame:
     """
     Get marginal detection probabilities from simulations.
     """
+    df = df.filter(pl.col("simulated"))
     n_infections = df.shape[0]
 
     # Add in eligibility conditions
@@ -204,13 +208,17 @@ def summarize_infections(df: pl.DataFrame) -> pl.DataFrame:
     """
     Get summaries of infectiousness from simulations.
     """
-    df = df.with_columns(
-        n_infections=pl.col("infection_times").list.len(),
-        t_noninfectious=pl.min_horizontal(
-            [pl.col("t_detected"), pl.col("t_recovered")]
-        ),
-    ).with_columns(
-        duration_infectious=(pl.col("t_noninfectious") - pl.col("t_infectious"))
+    df = (
+        df.filter(pl.col("simulated"))
+        .with_columns(
+            n_infections=pl.col("infection_times").list.len(),
+            t_noninfectious=pl.min_horizontal(
+                [pl.col("t_detected"), pl.col("t_recovered")]
+            ),
+        )
+        .with_columns(
+            duration_infectious=(pl.col("t_noninfectious") - pl.col("t_infectious"))
+        )
     )
 
     return pl.DataFrame(
@@ -230,15 +238,11 @@ def prob_control_by_gen(df: pl.DataFrame, gen: int) -> float:
     """
     n_sim = df["simulation"].unique().len()
     size_at_gen = (
-        df.with_columns(
-            pl.col("generation") + 1,
-            n_infections=pl.col("infection_times").list.len(),
-        )
-        .with_columns(size=pl.sum("n_infections").over("simulation", "generation"))
-        .unique(subset=["simulation", "generation"])
+        df.group_by("simulation", "generation")
+        .agg(n_infections=pl.len())
         .filter(
             pl.col("generation") == gen,
-            pl.col("size") > 0,
+            pl.col("n_infections") > 0,
         )
     )
     return 1.0 - (size_at_gen.shape[0] / n_sim)


### PR DESCRIPTION
Resolves #67, and since that changes the behavior of `max_infections` also resolves #65, should lay the groundwork to make resolving #62 easy.

The core changes here are:
1. `Simulation.create_person(self)` is now `create_person(self, infector: Optional[str], t_exposed: float, generation: int)`
2. `Simulation.run()` no longer calls `Simulation.create_person()` except for the index case. All other calls are in `Simulation.generate_infections()`

There are a number of cascading changes required to accommodate this, including to `Simulate` (e.g. adding a new property to track whether an individual was actually simulated or just initialized), to summarization (e.g. now we have to filter out the not-actually-simulated infections to count detections), and to plotting (all around the need to filter out purely-initialized infections).

I think the new approach has some nice side-effects:
1. It allows us to dispense with `Simulate.register_infectee()`
2. The dataframe wrangling in `prob_control_by_gen` is much more straightforward

This also frees us to remove the redundant `"infection_times"` property, which is now entirely retrievable from other, more needed, information (`[sim.get_person_property(infectee, "t_exposed") for infectee in sim.get_person_property(id, "infectees")]`). But that's out of scope here.
