### PR TITLE
Add plot of infections by generation

### DIFF
--- a/ringvax/app.py
+++ b/ringvax/app.py
@@ -205,8 +205,6 @@ def generational_summary(
         pl.col("num_infections").quantile(1.0 - alpha / 2).alias("uci"),
     )
 
-    st.dataframe(plot_data)
-
     base = alt.Chart(plot_data)
     cone = base.mark_area(opacity=0.3).encode(
         x="generation:N",


### PR DESCRIPTION
Another way one might want to see results, is a summary over generations, i.e., the cone of uncertainty over trajectories.

![image](https://github.com/user-attachments/assets/2dbd1909-a7fc-4580-92f4-79265720304c)

We probably now want some kind of selector, to choose whether we want:

1. Infections in G-th generation (histogram over simulations)
2. Cumulative infections by G-th generation (histogram over simulations)
3. Infections by generation (median & CI over simulations)

And will want to discard the table